### PR TITLE
Fixes enabling/disabling Smart Button on the wallbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -1365,6 +1365,7 @@ class Easee extends utils.Adapter {
             },
             native: {},
         });
+        this.subscribeStates(charger.id + '.config.smartButtonEnabled');
 
         //wiFiSSID
         await this.setObjectNotExistsAsync(charger.id + '.config.wiFiSSID', {


### PR DESCRIPTION
Damit kann die Konfig auch geschrieben werden. Wird benötigt, um den Smart Button auf der Wall zu aktivieren oder deaktivieren.